### PR TITLE
Issue #49: Bump laminas-cli to v1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Documentation is available at: https://docs.dotkernel.org/dot-cli/.
 ## Badges
 
 ![OSS Lifecycle](https://img.shields.io/osslifecycle/dotkernel/dot-cli)
-![PHP from Packagist (specify version)](https://img.shields.io/packagist/php-v/dotkernel/dot-cli/3.10.0)
+![PHP from Packagist (specify version)](https://img.shields.io/packagist/php-v/dotkernel/dot-cli/3.11.0)
 
 [![GitHub issues](https://img.shields.io/github/issues/dotkernel/dot-cli)](https://github.com/dotkernel/dot-cli/issues)
 [![GitHub forks](https://img.shields.io/github/forks/dotkernel/dot-cli)](https://github.com/dotkernel/dot-cli/network)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 
 | Version | Supported          | PHP Version                                                                                              |
 |---------|--------------------|----------------------------------------------------------------------------------------------------------|
-| 3.x     | :white_check_mark: | ![PHP from Packagist (specify version)](https://img.shields.io/packagist/php-v/dotkernel/dot-cli/3.10.0) |
+| 3.x     | :white_check_mark: | ![PHP from Packagist (specify version)](https://img.shields.io/packagist/php-v/dotkernel/dot-cli/3.11.0) |
 | <= 2.x  | :x:                |                                                                                                          |
 
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-        "laminas/laminas-cli": "^1.4.0",
+        "laminas/laminas-cli": "^1.15.0",
         "laminas/laminas-servicemanager": "^3.11.1 || ^4.0"
     },
     "autoload": {

--- a/docs/book/v3/overview.md
+++ b/docs/book/v3/overview.md
@@ -4,7 +4,7 @@
 > dot-cli is a wrapper on top of [laminas-cli](https://github.com/laminas/laminas-cli)
 
 ![OSS Lifecycle](https://img.shields.io/osslifecycle/dotkernel/dot-cli)
-![PHP from Packagist (specify version)](https://img.shields.io/packagist/php-v/dotkernel/dot-cli/3.10.0)
+![PHP from Packagist (specify version)](https://img.shields.io/packagist/php-v/dotkernel/dot-cli/3.11.0)
 
 [![GitHub issues](https://img.shields.io/github/issues/dotkernel/dot-cli)](https://github.com/dotkernel/dot-cli/issues)
 [![GitHub forks](https://img.shields.io/github/forks/dotkernel/dot-cli)](https://github.com/dotkernel/dot-cli/network)


### PR DESCRIPTION
Bump `laminas-cli` version from `1.4.0` to `1.15.0`